### PR TITLE
Revert "pin tornado"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,13 +5,14 @@ package:
   version: {{ version }}
 
 source:
+  fn: jupyter_client-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/j/jupyter_client/jupyter_client-{{ version }}.tar.gz
   sha256: b5f9cb06105c1d2d30719db5ffb3ea67da60919fb68deaefa583deccd8813551
 
 build:
   noarch: python
   number: 2
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - jupyter-kernelspec = jupyter_client.kernelspecapp:KernelSpecApp.launch_instance
     - jupyter-run = jupyter_client.runapp:main
@@ -27,7 +28,7 @@ requirements:
     - jupyter_core
     - python-dateutil >=2.1
     - pyzmq >=13
-    - tornado >=4.1,<6
+    - tornado
 
 test:
   commands:


### PR DESCRIPTION
reverts #21

jupyter-client doesn't appear to have any compatibility issues with tornado 6 (none have been reported, tests pass, etc.). The issue is in the web handlers in jupyter/notebook